### PR TITLE
Permission fix

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -98,5 +98,5 @@ set_permissions() {
   # set_perm  $MODPATH/system/bin/app_process32   0       2000    0755         u:object_r:zygote_exec:s0
   # set_perm  $MODPATH/system/bin/dex2oat         0       2000    0755         u:object_r:dex2oat_exec:s0
   # set_perm  $MODPATH/system/lib/libart.so       0       0       0644
-  set_perm  $MODPATH/system/bin/fmount  0  0  0777
+  set_perm  $MODPATH/system/bin/fmount  0  0  0775
 }


### PR DESCRIPTION
Fixed a permission flaw that would allow a malicious person or software to modify fmount without being authorized to.